### PR TITLE
Print file counts and optionally list of files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,28 @@
 # blame-bird.py
 This Python script tries to figure out which app uses a lot of
-space in the `Library/Caches/com.apple.bird` folder on your mac.
+space and files in the `Library/Caches/com.apple.bird` folder on your mac.
 
 ```
 $ python blame-bird.py
-4R6749AYRE.com.pixelmatorteam.pixelmator            0.00MB
-com.apple.shoebox                                   0.00MB
-com.apple.TextInput                                 0.00MB
-iCloud.com.apple.iBooks                             0.00MB
-57T9237FN3.net.whatsapp.WhatsApp                 6904.66MB
+4R6749AYRE.com.pixelmatorteam.pixelmator            0.00MB      1
+com.apple.shoebox                                   0.00MB      3
+com.apple.TextInput                                 0.00MB      7
+iCloud.com.apple.iBooks                             0.00MB      2
+57T9237FN3.net.whatsapp.WhatsApp                 6904.66MB    647
 
 Accounted for: 6904MB.  Still unaccounted: 1879MB
+```
+
+If you supply the app name as argument, the script generates a list of
+related files (uncomment `| xargs du -hs` to add file sizes).
+
+```
+$ python blame-bird.py com.apple.TextInput # | xargs du -hs
+/Users/usr/Library/Caches/com.apple.bird/session/g/C8E6D0A6-46A8-4803-8DDE-451341DD2DBA
+/Users/usr/Library/Caches/com.apple.bird/session/g/4DF22D5F-464A-4F11-9CC5-4D9A073E0D59
+/Users/usr/Library/Caches/com.apple.bird/session/g/8E0BB4C3-C0C6-495F-AC60-B750971EF17D
+/Users/usr/Library/Caches/com.apple.bird/session/g/9F21F0B3-26C3-4066-A11E-7A853DF7E4F5
+/Users/usr/Library/Caches/com.apple.bird/session/g/1FB77878-5975-47EC-A062-C7326FBBE496
+/Users/usr/Library/Caches/com.apple.bird/session/g/B4B6DCFE-9958-498E-9B53-8C6195A2CF30
+/Users/usr/Library/Caches/com.apple.bird/session/g/28456B01-2DDD-4F08-924A-6C1BB8F04464
 ```

--- a/blame-bird.py
+++ b/blame-bird.py
@@ -67,8 +67,8 @@ def main():
     for zone_id, size in sorted(zonesize.items(), key=lambda x: x[1]):
         if size == 0:
             continue
-        print('{:<45} {:>10.2f}MB'.format(zones[zone_id],
-                        zonesize[zone_id] / 1000000.))
+        print('{:<45} {:>10.2f}MB {:>6}'.format(zones[zone_id],
+                        zonesize[zone_id] / 1000000., len(zonefiles[zone_id])))
         accounted_size += zonesize[zone_id]
 
     for guid in unaccounted_for:

--- a/blame-bird.py
+++ b/blame-bird.py
@@ -57,9 +57,10 @@ def main():
 
     if len(sys.argv) > 1:
         if sys.argv[1] not in zones.values():
-            print 'error: app "' + sys.argv[1] + '" not found'
+            print('error: app "' + sys.argv[1] + '" not found')
             sys.exit(65)
-        zone_id = zones.keys()[zones.values().index(sys.argv[1])]
+        #zone_id = zones.keys()[zones.values().index(sys.argv[1])]
+        zone_id = list(zones.keys())[list(zones.values()).index(sys.argv[1])]
         for zone_file in zonefiles[zone_id]:
             print(zone_file)
         sys.exit(0)

--- a/blame-bird.py
+++ b/blame-bird.py
@@ -7,6 +7,7 @@ import os
 import uuid
 import sqlite3
 import os.path
+import sys
 
 def maybe_uuid(x):
     """ Tries to parse x as an UUID and return that, otherwise return None. """
@@ -53,6 +54,15 @@ def main():
 
     accounted_size = 0
     unaccounted_size = 0
+
+    if len(sys.argv) > 1:
+        if sys.argv[1] not in zones.values():
+            print 'error: app "' + sys.argv[1] + '" not found'
+            sys.exit(65)
+        zone_id = zones.keys()[zones.values().index(sys.argv[1])]
+        for zone_file in zonefiles[zone_id]:
+            print(zone_file)
+        sys.exit(0)
 
     for zone_id, size in sorted(zonesize.items(), key=lambda x: x[1]):
         if size == 0:

--- a/blame-bird.py
+++ b/blame-bird.py
@@ -30,9 +30,11 @@ def main():
 
     zones = {}
     zonesize = {}
+    zonefiles = {}
     for rowid, name in c.execute('select rowid, zone_name from client_zones'):
         zones[rowid] = name
         zonesize[rowid] = 0
+        zonefiles[rowid] = []
 
     for raw_guid, zone_id in c.execute(
             'select item_id, zone_rowid from client_unapplied_table'):
@@ -46,6 +48,7 @@ def main():
         if not os.path.exists(path):
             continue
         zonesize[zone_id] += os.stat(path).st_size
+        zonefiles[zone_id].append(path)
         unaccounted_for.remove(guid)
 
     accounted_size = 0


### PR DESCRIPTION
Hi,

Many thanks for the code. I was looking for a way to remove files belonging to a certain app (in my case WhatsApp). So I modified the script:

* Print number of files in addition to space used by app.
* If app name is supplied as first argument, print all files that belong to the app instead default print.

See example in `README.md` (where fictional counts are added). Used this with `| xargs du -hs` to check single file sizes and `| xargs rm -r` to delete the files. Feel free to merge.

Regards,
Sven